### PR TITLE
Enhancements to telemetry and lap racing

### DIFF
--- a/GhostReplay/ReplayData.cpp
+++ b/GhostReplay/ReplayData.cpp
@@ -109,6 +109,7 @@ void CReplayData::Write() {
             { "RPM", Node.RPM },
             { "LowBeams", Node.LowBeams },
             { "HighBeams", Node.HighBeams },
+            { "VehicleSpeed", Node.VehicleSpeed },
         });
     }
 

--- a/GhostReplay/ReplayData.hpp
+++ b/GhostReplay/ReplayData.hpp
@@ -6,21 +6,23 @@
 #include <vector>
 
 struct SReplayNode {
-    unsigned long long Timestamp;
+    unsigned long long Timestamp; // milliseconds
     Vector3 Pos;
-    Vector3 Rot;
-    std::vector<float> WheelRotations;
+    Vector3 Rot; // roll/pitch/yaw, degrees
+    std::vector<float> WheelRotations; // radians
     std::vector<float> SuspensionCompressions;
 
-    float SteeringAngle;
-    float Throttle;
-    float Brake;
+    float SteeringAngle; // steering input angle dependent on steering lock, radians
+    float Throttle; // 0-1, percentage
+    float Brake; // 0-1, percentage
 
     int Gear;
-    float RPM;
+    float RPM; // 0-1, percentage
 
     bool LowBeams;
     bool HighBeams;
+
+    float VehicleSpeed; // meters/second
 
     bool operator<(const SReplayNode& other) const {
         return Timestamp < other.Timestamp;

--- a/GhostReplay/ReplayMenu.cpp
+++ b/GhostReplay/ReplayMenu.cpp
@@ -483,6 +483,10 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
             { "Draws green flares for the track start, red flares for the track finish.",
               "Setting applies next time a track is selected." });
 
+        mbCtx.BoolOption("Extensive replay telemetry", GetSettings().Main.ExtensiveReplayTelemetry,
+            { "Adds additional telemetry data to replay files.",
+              "May impact performance." });
+
         mbCtx.MenuOption("Recording options", "recordoptionsmenu");
         mbCtx.MenuOption("Replay/ghost options", "replayoptionsmenu");
     });

--- a/GhostReplay/ReplayScript.cpp
+++ b/GhostReplay/ReplayScript.cpp
@@ -460,7 +460,18 @@ void CReplayScript::updatePlayback(unsigned long long gameTime, bool startPassed
             VEHICLE::SET_VEHICLE_FULLBEAM(mReplayVehicle, nodeCurr->HighBeams);
 
             if (replayTime >= 5000 && finishPassedThisTick) {
-                mReplayState = EReplayState::Finished;
+                if (startPassedThisTick) {
+                    mReplayState = EReplayState::Playing;
+                    replayStart = gameTime;
+                    ENTITY::SET_ENTITY_VISIBLE(mReplayVehicle, true, true);
+                    ENTITY::SET_ENTITY_ALPHA(mReplayVehicle, map(mSettings.Replay.VehicleAlpha, 0, 100, 0, 255), false);
+                    ENTITY::SET_ENTITY_COMPLETELY_DISABLE_COLLISION(mReplayVehicle, false, false);
+                    VEHICLE::SET_VEHICLE_ENGINE_ON(mReplayVehicle, true, true, false);
+                    mLastNode = mActiveReplay->Nodes.begin();
+                }
+                else {
+                    mReplayState = EReplayState::Finished;
+                }
                 //UI::Notify("Player finished", false);
             }
             break;
@@ -592,6 +603,21 @@ void CReplayScript::updateRecord(unsigned long long gameTime, bool startPassedTh
 
                 if (mSettings.Main.NotifyLaps) {
                     UI::Notify(lapInfo, false);
+                }
+
+                if (startPassedThisTick) {
+                    mCurrentRun = CReplayData("");
+                    mRecordState = ERecordState::Recording;
+                    recordStart = gameTime;
+                    mCurrentRun.Timestamp = std::chrono::duration_cast<std::chrono::milliseconds>
+                        (std::chrono::system_clock::now().time_since_epoch()).count();
+                    mCurrentRun.Track = mActiveTrack->Name;
+                    mCurrentRun.Nodes.clear();
+                    mCurrentRun.VehicleModel = ENTITY::GET_ENTITY_MODEL(vehicle);
+
+                    VehicleModData modData = VehicleModData::LoadFrom(vehicle);
+                    mCurrentRun.VehicleMods = modData;
+                    //UI::Notify("Record started", false);
                 }
             }
             break;

--- a/GhostReplay/ReplayScript.cpp
+++ b/GhostReplay/ReplayScript.cpp
@@ -531,6 +531,14 @@ void CReplayScript::updateRecord(unsigned long long gameTime, bool startPassedTh
             node.LowBeams = areLowBeamsOn;
             node.HighBeams = areHighBeamsOn;
 
+            // Only make use of all that stuff if ExtensiveReplayTelemetry is used
+            if (mSettings.Main.ExtensiveReplayTelemetry) {
+                node.VehicleSpeed = ENTITY::GET_ENTITY_SPEED(vehicle);
+            }
+            else {
+                node.VehicleSpeed = 0.0f;
+            }
+
             bool saved = false;
             unsigned long long lastNodeTime = 0;
             if (!mCurrentRun.Nodes.empty()) {

--- a/GhostReplay/ReplayScript.cpp
+++ b/GhostReplay/ReplayScript.cpp
@@ -459,7 +459,7 @@ void CReplayScript::updatePlayback(unsigned long long gameTime, bool startPassed
             VEHICLE::SET_VEHICLE_LIGHTS(mReplayVehicle, nodeCurr->LowBeams ? 3 : 4);
             VEHICLE::SET_VEHICLE_FULLBEAM(mReplayVehicle, nodeCurr->HighBeams);
 
-            if (finishPassedThisTick) {
+            if (replayTime >= 5000 && finishPassedThisTick) {
                 mReplayState = EReplayState::Finished;
                 //UI::Notify("Player finished", false);
             }
@@ -549,7 +549,7 @@ void CReplayScript::updateRecord(unsigned long long gameTime, bool startPassedTh
                 saved = true;
             }
 
-            if (finishPassedThisTick) {
+            if (node.Timestamp >= 5000 && finishPassedThisTick) {
                 mRecordState = ERecordState::Finished;
                 if (!saved) {
                     mCurrentRun.Nodes.push_back(node);

--- a/GhostReplay/ScriptSettings.cpp
+++ b/GhostReplay/ScriptSettings.cpp
@@ -30,7 +30,12 @@ void CScriptSettings::Load() {
 
     LOAD_VAL("Main", "NotifyLaps", Main.NotifyLaps);
     LOAD_VAL("Main", "DrawStartFinish", Main.DrawStartFinish);
-    LOAD_VAL("Main", "ExtensiveReplayTelemetry", Main.ExtensiveReplayTelemetry);
+    try {
+        LOAD_VAL("Main", "ExtensiveReplayTelemetry", Main.ExtensiveReplayTelemetry);
+    }
+    catch (std::exception) {
+        Main.ExtensiveReplayTelemetry = false;
+    }
 
     LOAD_VAL("Record", "AutoGhost", Record.AutoGhost);
     LOAD_VAL("Record", "DeltaMillis", Record.DeltaMillis);

--- a/GhostReplay/ScriptSettings.cpp
+++ b/GhostReplay/ScriptSettings.cpp
@@ -30,6 +30,7 @@ void CScriptSettings::Load() {
 
     LOAD_VAL("Main", "NotifyLaps", Main.NotifyLaps);
     LOAD_VAL("Main", "DrawStartFinish", Main.DrawStartFinish);
+    LOAD_VAL("Main", "ExtensiveReplayTelemetry", Main.ExtensiveReplayTelemetry);
 
     LOAD_VAL("Record", "AutoGhost", Record.AutoGhost);
     LOAD_VAL("Record", "DeltaMillis", Record.DeltaMillis);
@@ -48,6 +49,7 @@ void CScriptSettings::Save() {
 
     SAVE_VAL("Main", "NotifyLaps", Main.NotifyLaps);
     SAVE_VAL("Main", "DrawStartFinish", Main.DrawStartFinish);
+    SAVE_VAL("Main", "ExtensiveReplayTelemetry", Main.ExtensiveReplayTelemetry);
 
     SAVE_VAL("Record", "AutoGhost", Record.AutoGhost);
     SAVE_VAL("Record", "DeltaMillis", Record.DeltaMillis);

--- a/GhostReplay/ScriptSettings.hpp
+++ b/GhostReplay/ScriptSettings.hpp
@@ -11,6 +11,7 @@ public:
     struct {
         bool NotifyLaps = true;
         bool DrawStartFinish = true;
+        bool ExtensiveReplayTelemetry = false;
     } Main;
 
     struct {


### PR DESCRIPTION
* Added extensive telemetry setting, replay files include vehicle speed if this option is enabled
* Recording and ghost playback now cannot end within 5 seconds  
The comments in ReplayScript.cpp note `b. The run ignores < 5.0 second runs.` but this behavior was never coded in - this is now rectified
* Passing the start and finish lines on the same tick starts a new recording and replay while ending the previous one simultaneously, meaning that you can have proper lap races instead of placing the finish line somewhere ahead of the start line  
You probably want to update ARS handling to take this into account  
Note that there is a minor bug if AutoGhost is true and a new best lap is set, see metoxys/GTAVGhostReplay#5