### PR TITLE
Use FrameTime to calculate timestamps

### DIFF
--- a/GhostReplay/Constants.hpp
+++ b/GhostReplay/Constants.hpp
@@ -3,7 +3,7 @@
 #define STR(x) STR_HELPER(x)
 
 #define VERSION_MAJOR 1
-#define VERSION_MINOR 2
+#define VERSION_MINOR 3
 #define VERSION_PATCH 0
 
 namespace Constants {

--- a/GhostReplay/ReplayData.hpp
+++ b/GhostReplay/ReplayData.hpp
@@ -6,7 +6,7 @@
 #include <vector>
 
 struct SReplayNode {
-    unsigned long long Timestamp;
+    double Timestamp;
     Vector3 Pos;
     Vector3 Rot;
     std::vector<float> WheelRotations;

--- a/GhostReplay/ReplayMenu.cpp
+++ b/GhostReplay/ReplayMenu.cpp
@@ -686,7 +686,7 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
 
         mbCtx.BoolOption("Zero velocity on pause", GetSettings().Replay.ZeroVelocityOnPause,
             { "When paused, no velocity is set. This stops the third person gameplay camera from moving, "
-              "but will cause glitches for vehicles with advanced handling flag 0x0800000." });
+              "but will cause glitched suspension for vehicles with advanced handling flag 0x0800000." });
     });
 
     return submenus;

--- a/GhostReplay/ReplayMenu.cpp
+++ b/GhostReplay/ReplayMenu.cpp
@@ -500,8 +500,12 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
         mbCtx.Title("Ghost controls");
         mbCtx.Subtitle("");
 
-        mbCtx.FloatOptionCb("Offset (seconds)", GetSettings().Replay.OffsetSeconds, -60.0f, 60.0f, 0.05f,
+        float offset = static_cast<float>(GetSettings().Replay.OffsetSeconds);
+        bool offsetChanged = mbCtx.FloatOptionCb("Offset (seconds)", offset, -60.0f, 60.0f, 0.05f,
             MenuUtils::GetKbFloat, { "Ghost offset. Positive is in front, negative is behind." });
+        if (offsetChanged) {
+            GetSettings().Replay.OffsetSeconds = static_cast<double>(offset);
+        }
 
         const std::vector<std::string> replayAlphaDescr{
             "The transparency of the ghost vehicle.",
@@ -529,7 +533,7 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
             mbCtx.Option("~m~Replay controls unavailable", { "Select a track and a replay." });
         }
         else {
-            const uint32_t scrubDist = 1000;
+            const double scrubDist = 1000.0; // milliseconds
             auto activeReplay = context.ActiveReplay();
             auto replayState = context.GetReplayState();
             std::string replayStateName;

--- a/GhostReplay/ReplayMenu.cpp
+++ b/GhostReplay/ReplayMenu.cpp
@@ -683,6 +683,10 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
 
         mbCtx.BoolOption("Force fallback model", GetSettings().Replay.ForceFallbackModel, 
             { "Always use the fallback model." });
+
+        mbCtx.BoolOption("Zero velocity on pause", GetSettings().Replay.ZeroVelocityOnPause,
+            { "When paused, no velocity is set. This stops the third person gameplay camera from moving, "
+              "but will cause glitches for vehicles with advanced handling flag 0x0800000." });
     });
 
     return submenus;

--- a/GhostReplay/ReplayMenu.cpp
+++ b/GhostReplay/ReplayMenu.cpp
@@ -565,7 +565,7 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
 
             if (GetSettings().Main.Debug) {
                 bool pause = mbCtx.OptionPlus(
-                    fmt::format("<< [{}/{}] >>", context.GetFrameIndex(), context.GetNumFrames()),
+                    fmt::format("<< [{}/{}] >>", context.GetFrameIndex(), context.GetNumFrames() - 1),
                     playbackDetails,
                     nullptr,
                     [&]() { context.FrameNext(); },

--- a/GhostReplay/ReplayScript.hpp
+++ b/GhostReplay/ReplayScript.hpp
@@ -96,7 +96,7 @@ public:
     std::vector<std::shared_ptr<CReplayData>> GetCompatibleReplays(const std::string& trackName);
     void AddCompatibleReplay(const CReplayData& value);
 
-    bool IsFastestLap(const std::string& trackName, Hash vehicleModel, unsigned long long timestamp);
+    bool IsFastestLap(const std::string& trackName, Hash vehicleModel, double timestamp);
     CReplayData GetFastestReplay(const std::string& trackName, Hash vehicleModel);
 
     bool StartLineDef(SLineDef& lineDef, const std::string& lineName);
@@ -111,10 +111,10 @@ public:
     bool IsPassengerModeActive() { return mPassengerModeActive; }
 
     // Playback control
-    uint64_t GetReplayProgress();
+    double GetReplayProgress();
     void TogglePause(bool pause);
-    void ScrubBackward(uint64_t millis);
-    void ScrubForward(uint64_t millis);
+    void ScrubBackward(double step);
+    void ScrubForward(double step);
 
     // Debugging playback
     uint64_t GetNumFrames();
@@ -126,16 +126,21 @@ public:
 
 protected:
     void updateReplay();
-    void updateRecord(unsigned long long gameTime, bool startPassedThisTick, bool finishPassedThisTick);
+    void updateRecord(double gameTime, bool startPassedThisTick, bool finishPassedThisTick);
     void updateTrackDefine();
     bool passedLineThisTick(SLineDef line, Vector3 oldPos, Vector3 newPos);
-    void startRecord(unsigned long long gameTime, Vehicle vehicle);
-    bool saveNode(unsigned long long gameTime, SReplayNode& node, Vehicle vehicle, bool firstNode);
+    void startRecord(double gameTime, Vehicle vehicle);
+    bool saveNode(double gameTime, SReplayNode& node, Vehicle vehicle, bool firstNode);
     void finishRecord(bool saved, const SReplayNode& node);
     void clearPtfx();
     void createPtfx(const CTrackData& trackData);
     void clearTrackBlips();
     void createTrackBlips(const CTrackData& trackData);
+
+    void updateSteppedTime();
+    double getSteppedTime();
+
+    double mCurrentTime;
 
     const CScriptSettings& mSettings;
     std::vector<std::shared_ptr<CReplayData>>& mReplays;
@@ -152,7 +157,7 @@ protected:
 
     EScriptMode mScriptMode;
     ERecordState mRecordState;
-    unsigned long long recordStart = 0;
+    double mRecordStart = 0.0;
 
     Vector3 mLastPos;
 

--- a/GhostReplay/ReplayScriptUtils.cpp
+++ b/GhostReplay/ReplayScriptUtils.cpp
@@ -21,15 +21,16 @@ std::string Util::StripString(std::string input) {
     return input;
 }
 
-std::string Util::FormatMillisTime(unsigned long long totalTime) {
-    unsigned long long milliseconds = totalTime % 1000;
-    unsigned long long seconds = (totalTime / 1000) % 60;
-    unsigned long long minutes = (totalTime / 1000) / 60;
+std::string Util::FormatMillisTime(double totalTime) {
+    auto timeMillis = static_cast<uint32_t>(totalTime);
+    unsigned long long milliseconds = timeMillis % 1000;
+    unsigned long long seconds = (timeMillis / 1000) % 60;
+    unsigned long long minutes = (timeMillis / 1000) / 60;
     return fmt::format("{}:{:02d}.{:03d}", minutes, seconds, milliseconds);
 }
 
 std::string Util::FormatReplayName(
-    unsigned long long totalTime,
+    double totalTime,
     const std::string& trackName,
     const std::string& vehicleName) {
     std::string timeStr = Util::FormatMillisTime(totalTime);

--- a/GhostReplay/ReplayScriptUtils.hpp
+++ b/GhostReplay/ReplayScriptUtils.hpp
@@ -4,9 +4,9 @@
 
 namespace Util {
     std::string StripString(std::string input);
-    std::string FormatMillisTime(unsigned long long totalTime);
+    std::string FormatMillisTime(double totalTime);
     std::string FormatReplayName(
-        unsigned long long totalTime,
+        double totalTime,
         const std::string& trackName,
         const std::string& vehicleName);
     std::string GetVehicleName(Hash model);

--- a/GhostReplay/ReplayVehicle.cpp
+++ b/GhostReplay/ReplayVehicle.cpp
@@ -235,7 +235,7 @@ void CReplayVehicle::showNode(
     ENTITY::SET_ENTITY_ROTATION(mReplayVehicle, rot.x, rot.y, rot.z, 0, false);
 
     // Prevent the third person camera from rotating backwards
-    if (!paused) {
+    if (!(paused && mSettings.Replay.ZeroVelocityOnPause)) {
         Vector3 vel = (nodeNext->Pos - nodeCurr->Pos) * static_cast<float>(1.0 / deltaT);
         ENTITY::SET_ENTITY_VELOCITY(mReplayVehicle, vel.x, vel.y, vel.z);
     }

--- a/GhostReplay/ReplayVehicle.cpp
+++ b/GhostReplay/ReplayVehicle.cpp
@@ -26,7 +26,7 @@ CReplayVehicle::~CReplayVehicle() {
         resetReplay();
 }
 
-void CReplayVehicle::UpdatePlayback(unsigned long long gameTime, bool startPassedThisTick, bool finishPassedThisTick) {
+void CReplayVehicle::UpdatePlayback(double gameTime, bool startPassedThisTick, bool finishPassedThisTick) {
     if (!mActiveReplay) {
         mReplayState = EReplayState::Idle;
         resetReplay();
@@ -53,7 +53,7 @@ void CReplayVehicle::UpdatePlayback(unsigned long long gameTime, bool startPasse
         case EReplayState::Playing: {
             // The time that has elapsed from the viewpoint of the replay.
             auto replayTime = gameTime - mReplayStart;
-            replayTime += static_cast<int>(mSettings.Replay.OffsetSeconds * 1000.0f);
+            replayTime += mSettings.Replay.OffsetSeconds * 1000.0;
 
             // Find the node where the timestamp is larger than the current virtual timestamp (replayTime).
             auto nodeNext = std::upper_bound(mLastNode, mActiveReplay->Nodes.end(), SReplayNode{ replayTime });
@@ -87,14 +87,14 @@ void CReplayVehicle::UpdatePlayback(unsigned long long gameTime, bool startPasse
     }
 }
 
-uint64_t CReplayVehicle::GetReplayProgress() {
+double CReplayVehicle::GetReplayProgress() {
     if (mActiveReplay && mLastNode != mActiveReplay->Nodes.end()) {
         return mLastNode->Timestamp;
     }
     return 0;
 }
 
-void CReplayVehicle::TogglePause(bool pause, uint64_t gameTime) {
+void CReplayVehicle::TogglePause(bool pause, double gameTime) {
     if (mReplayState == EReplayState::Idle) {
         startReplay(gameTime);
     }
@@ -103,7 +103,7 @@ void CReplayVehicle::TogglePause(bool pause, uint64_t gameTime) {
     }
     else {
         mReplayState = EReplayState::Playing;
-        uint64_t offset = 0;
+        double offset = 0.0;
         if (mActiveReplay && mLastNode != mActiveReplay->Nodes.end()) {
             offset = mLastNode->Timestamp;
         }
@@ -111,10 +111,10 @@ void CReplayVehicle::TogglePause(bool pause, uint64_t gameTime) {
     }
 }
 
-void CReplayVehicle::ScrubBackward(uint64_t millis) {
+void CReplayVehicle::ScrubBackward(double step) {
     if (mActiveReplay && mLastNode != mActiveReplay->Nodes.end()) {
-        bool wouldSkipPastBegin = mLastNode->Timestamp < millis;
-        auto minMillis = wouldSkipPastBegin ? mLastNode->Timestamp : millis;
+        bool wouldSkipPastBegin = mLastNode->Timestamp < step;
+        auto minMillis = wouldSkipPastBegin ? mLastNode->Timestamp : step;
 
         auto replayTime = mLastNode->Timestamp - minMillis;
         auto nodeCurr = std::lower_bound(mActiveReplay->Nodes.begin(), mLastNode, SReplayNode{ replayTime });
@@ -124,22 +124,22 @@ void CReplayVehicle::ScrubBackward(uint64_t millis) {
     }
 }
 
-void CReplayVehicle::ScrubForward(uint64_t millis) {
+void CReplayVehicle::ScrubForward(double step) {
     if (mActiveReplay && mLastNode != mActiveReplay->Nodes.end()) {
-        bool wouldSkipPastEnd = mLastNode->Timestamp + millis > mActiveReplay->Nodes.back().Timestamp;
+        bool wouldSkipPastEnd = mLastNode->Timestamp + step > mActiveReplay->Nodes.back().Timestamp;
         if (wouldSkipPastEnd) {
             mReplayState = EReplayState::Idle;
             resetReplay();
             return;
         }
 
-        auto replayTime = mLastNode->Timestamp + millis;
+        auto replayTime = mLastNode->Timestamp + step;
         auto nodeCurr = std::upper_bound(mLastNode, mActiveReplay->Nodes.end(), SReplayNode{ replayTime });
         if (nodeCurr != mActiveReplay->Nodes.begin())
             nodeCurr = std::prev(nodeCurr);
 
         mLastNode = nodeCurr;
-        mReplayStart -= millis;
+        mReplayStart -= step;
     }
 }
 
@@ -148,14 +148,6 @@ uint64_t CReplayVehicle::GetNumFrames() {
         return mActiveReplay->Nodes.size();
     return 0;
 }
-
-struct SMyStruct {
-    float Value;
-
-    bool operator<(const SMyStruct& other) const {
-        return Value < other.Value;
-    }
-};
 
 uint64_t CReplayVehicle::GetFrameIndex() {
     if (!mActiveReplay || mLastNode == mActiveReplay->Nodes.end())
@@ -199,7 +191,7 @@ void CReplayVehicle::FrameNext() {
     mReplayStart -= delta;
 }
 
-void CReplayVehicle::startReplay(unsigned long long gameTime) {
+void CReplayVehicle::startReplay(double gameTime) {
     mReplayStart = gameTime;
     unhideVehicle();
     mLastNode = mActiveReplay->Nodes.begin();
@@ -209,7 +201,7 @@ void CReplayVehicle::startReplay(unsigned long long gameTime) {
 }
 
 void CReplayVehicle::showNode(
-    unsigned long long replayTime,
+    double replayTime,
     std::vector<SReplayNode>::iterator nodeCurr,
     std::vector<SReplayNode>::iterator nodeNext) {
     // In paused state, nodeCurr == nodeNext, so fake-progress nodeNext.
@@ -218,9 +210,9 @@ void CReplayVehicle::showNode(
     if (paused)
         nodeNext = std::next(nodeNext);
 
-    float progress = ((float)replayTime - (float)nodeCurr->Timestamp) /
-        ((float)nodeNext->Timestamp - (float)nodeCurr->Timestamp);
-    float deltaT = ((nodeNext->Timestamp - nodeCurr->Timestamp) * 0.001f); // Seconds
+    float progress = static_cast<float>((replayTime - nodeCurr->Timestamp) /
+        (nodeNext->Timestamp - nodeCurr->Timestamp));
+    double deltaT = ((nodeNext->Timestamp - nodeCurr->Timestamp) * 0.001); // Seconds
     Vector3 pos = lerp(nodeCurr->Pos, nodeNext->Pos, progress);
     Vector3 rot = lerp(nodeCurr->Rot, nodeNext->Rot, progress, -180.0f, 180.0f);
     ENTITY::SET_ENTITY_COORDS_NO_OFFSET(mReplayVehicle, pos.x, pos.y, pos.z, false, false, false);
@@ -228,7 +220,7 @@ void CReplayVehicle::showNode(
 
     // Prevent the third person camera from rotating backwards
     if (!paused) {
-        Vector3 vel = (nodeNext->Pos - nodeCurr->Pos) * (1.0f / deltaT);
+        Vector3 vel = (nodeNext->Pos - nodeCurr->Pos) * static_cast<float>(1.0 / deltaT);
         ENTITY::SET_ENTITY_VELOCITY(mReplayVehicle, vel.x, vel.y, vel.z);
     }
 
@@ -239,7 +231,7 @@ void CReplayVehicle::showNode(
     rotInRad.y = deg2rad(rotInRad.y);
     rotInRad.z = deg2rad(rotInRad.z);
     Vector3 offNext = GetRelativeOffsetGivenWorldCoords(nodeCurr->Pos, nodeNext->Pos, rotInRad);
-    Vector3 relVel = offNext * (1.0f / deltaT);
+    Vector3 relVel = offNext * static_cast<float>(1.0 / deltaT);
 
     auto wheelDims = VExt::GetWheelDimensions(mReplayVehicle);
     if (VExt::GetNumWheels(mReplayVehicle) == nodeCurr->WheelRotations.size()) {

--- a/GhostReplay/ReplayVehicle.cpp
+++ b/GhostReplay/ReplayVehicle.cpp
@@ -119,6 +119,12 @@ void CReplayVehicle::ScrubBackward(double step) {
         auto replayTime = mLastNode->Timestamp - minMillis;
         auto nodeCurr = std::lower_bound(mActiveReplay->Nodes.begin(), mLastNode, SReplayNode{ replayTime });
 
+        // Step is smaller than delta-time, so just go to the previous frame.
+        if (nodeCurr != mActiveReplay->Nodes.begin() && nodeCurr == mLastNode) {
+            FramePrev();
+            return;
+        }
+
         mLastNode = nodeCurr;
         mReplayStart += minMillis;
     }
@@ -137,6 +143,12 @@ void CReplayVehicle::ScrubForward(double step) {
         auto nodeCurr = std::upper_bound(mLastNode, mActiveReplay->Nodes.end(), SReplayNode{ replayTime });
         if (nodeCurr != mActiveReplay->Nodes.begin())
             nodeCurr = std::prev(nodeCurr);
+
+        // Step is smaller than delta-time, so just go to the next frame.
+        if (std::next(nodeCurr) != mActiveReplay->Nodes.end() && nodeCurr == mLastNode) {
+            FrameNext();
+            return;
+        }
 
         mLastNode = nodeCurr;
         mReplayStart -= step;

--- a/GhostReplay/ReplayVehicle.cpp
+++ b/GhostReplay/ReplayVehicle.cpp
@@ -168,7 +168,7 @@ uint64_t CReplayVehicle::GetFrameIndex() {
     //return static_cast<uint64_t>(std::distance(mActiveReplay->Nodes.begin(), mLastNode));
 
     for (uint64_t i = 0; i < mActiveReplay->Nodes.size(); ++i) {
-        if (mLastNode->Timestamp == mActiveReplay->Nodes[i].Timestamp)
+        if (mLastNode->Timestamp <= mActiveReplay->Nodes[i].Timestamp)
             return i;
     }
     return 0;
@@ -194,9 +194,6 @@ void CReplayVehicle::FrameNext() {
     if (std::next(mLastNode) == mActiveReplay->Nodes.end())
         return;
 
-    if (std::next(std::next(mLastNode)) == mActiveReplay->Nodes.end())
-        return;
-
     auto nextIt = std::next(mLastNode);
     auto delta = nextIt->Timestamp - mLastNode->Timestamp;
     mLastNode = nextIt;
@@ -219,8 +216,14 @@ void CReplayVehicle::showNode(
     // In paused state, nodeCurr == nodeNext, so fake-progress nodeNext.
     // Make sure the frame control doesn't go further than std::next(nodeCurr) == end();
     bool paused = nodeCurr == nodeNext;
-    if (paused)
-        nodeNext = std::next(nodeNext);
+    if (paused) {
+        if (std::next(nodeNext) != mActiveReplay->Nodes.end()) {
+            nodeNext = std::next(nodeNext);
+        }
+        else {
+            nodeCurr = std::prev(nodeCurr);
+        }
+    }
 
     float progress = static_cast<float>((replayTime - nodeCurr->Timestamp) /
         (nodeNext->Timestamp - nodeCurr->Timestamp));

--- a/GhostReplay/ReplayVehicle.hpp
+++ b/GhostReplay/ReplayVehicle.hpp
@@ -23,7 +23,7 @@ public:
 
     Vehicle GetVehicle() { return mReplayVehicle; }
 
-    void UpdatePlayback(unsigned long long gameTime, bool startPassedThisTick, bool finishPassedThisTick);
+    void UpdatePlayback(double gameTime, bool startPassedThisTick, bool finishPassedThisTick);
 
     EReplayState GetReplayState() {
         return mReplayState;
@@ -35,10 +35,10 @@ public:
     }
 
     // Playback control
-    uint64_t GetReplayProgress();
-    void TogglePause(bool pause, uint64_t gameTime);
-    void ScrubBackward(uint64_t millis);
-    void ScrubForward(uint64_t millis);
+    double GetReplayProgress();
+    void TogglePause(bool pause, double gameTime);
+    void ScrubBackward(double step);
+    void ScrubForward(double step);
 
     // Debugging playback
     uint64_t GetNumFrames();
@@ -54,13 +54,13 @@ private:
     std::unique_ptr<CWrappedBlip> mReplayVehicleBlip;
 
     EReplayState mReplayState;
-    unsigned long long mReplayStart = 0;
+    double mReplayStart = 0.0;
     std::vector<SReplayNode>::iterator mLastNode;
 
     std::function<void(Vehicle)> mOnCleanup;
 
-    void startReplay(unsigned long long gameTime);
-    void showNode(unsigned long long replayTime,
+    void startReplay(double gameTime);
+    void showNode(double replayTime,
         std::vector<SReplayNode>::iterator nodeCurr,
         std::vector<SReplayNode>::iterator nodeNext);
     void resetReplay();

--- a/GhostReplay/ScriptSettings.cpp
+++ b/GhostReplay/ScriptSettings.cpp
@@ -44,6 +44,7 @@ void CScriptSettings::Load() {
     LOAD_VAL("Replay", "FallbackModel", Replay.FallbackModel);
     LOAD_VAL("Replay", "ForceFallbackModel", Replay.ForceFallbackModel);
     LOAD_VAL("Replay", "AutoLoadGhost", Replay.AutoLoadGhost);
+    LOAD_VAL("Replay", "ZeroVelocityOnPause", Replay.ZeroVelocityOnPause);
 }
 
 void CScriptSettings::Save() {
@@ -67,6 +68,7 @@ void CScriptSettings::Save() {
     SAVE_VAL("Replay", "FallbackModel", Replay.FallbackModel);
     SAVE_VAL("Replay", "ForceFallbackModel", Replay.ForceFallbackModel);
     SAVE_VAL("Replay", "AutoLoadGhost", Replay.AutoLoadGhost);
+    SAVE_VAL("Replay", "ZeroVelocityOnPause", Replay.ZeroVelocityOnPause);
 
     result = ini.SaveFile(mSettingsFile.c_str());
     CHECK_LOG_SI_ERROR(result, "save");

--- a/GhostReplay/ScriptSettings.hpp
+++ b/GhostReplay/ScriptSettings.hpp
@@ -23,7 +23,7 @@ public:
 
     struct {
         // Normal
-        float OffsetSeconds = 0.0f;
+        double OffsetSeconds = 0.0;
         int VehicleAlpha = 40;
         int ForceLights = 0;
 

--- a/GhostReplay/ScriptSettings.hpp
+++ b/GhostReplay/ScriptSettings.hpp
@@ -31,6 +31,7 @@ public:
         std::string FallbackModel = "sultan";
         bool ForceFallbackModel = false;
         bool AutoLoadGhost = true;
+        bool ZeroVelocityOnPause = false;
     } Replay;
 
 private:

--- a/GhostReplay/ScriptSettings.hpp
+++ b/GhostReplay/ScriptSettings.hpp
@@ -31,7 +31,7 @@ public:
         std::string FallbackModel = "sultan";
         bool ForceFallbackModel = false;
         bool AutoLoadGhost = true;
-        bool ZeroVelocityOnPause = false;
+        bool ZeroVelocityOnPause = true;
     } Replay;
 
 private:

--- a/GhostReplay/SettingsCommon.cpp
+++ b/GhostReplay/SettingsCommon.cpp
@@ -16,6 +16,10 @@ void SetValue(CSimpleIniA& ini, const char* section, const char* key, float val)
     ini.SetDoubleValue(section, key, static_cast<double>(val));
 }
 
+void SetValue(CSimpleIniA& ini, const char* section, const char* key, double val) {
+    ini.SetDoubleValue(section, key, val);
+}
+
 int GetValue(CSimpleIniA& ini, const char* section, const char* key, int val) {
     return ini.GetLongValue(section, key, val);
 }
@@ -30,4 +34,8 @@ bool GetValue(CSimpleIniA& ini, const char* section, const char* key, bool val) 
 
 float GetValue(CSimpleIniA& ini, const char* section, const char* key, float val) {
     return static_cast<float>(ini.GetDoubleValue(section, key, val));
+}
+
+double GetValue(CSimpleIniA& ini, const char* section, const char* key, double val) {
+    return ini.GetDoubleValue(section, key, val);
 }

--- a/GhostReplay/SettingsCommon.h
+++ b/GhostReplay/SettingsCommon.h
@@ -5,8 +5,10 @@ void SetValue(CSimpleIniA& ini, const char* section, const char* key, int val);
 void SetValue(CSimpleIniA& ini, const char* section, const char* key, const std::string& val);
 void SetValue(CSimpleIniA& ini, const char* section, const char* key, bool val);
 void SetValue(CSimpleIniA& ini, const char* section, const char* key, float val);
+void SetValue(CSimpleIniA& ini, const char* section, const char* key, double val);
 
 int GetValue(CSimpleIniA& ini, const char* section, const char* key, int val);
 std::string GetValue(CSimpleIniA& ini, const char* section, const char* key, const std::string& val);
 bool GetValue(CSimpleIniA& ini, const char* section, const char* key, bool val);
 float GetValue(CSimpleIniA& ini, const char* section, const char* key, float val);
+double GetValue(CSimpleIniA& ini, const char* section, const char* key, double val);


### PR DESCRIPTION
Solves noticeable jittering at high (200+ kph) speeds. Now stable (tested) up to 1100 km/h. See also [GTAForums thread](https://gtaforums.com/topic/973159-general-issues-with-recording-and-replaying-moving-entities-from-scripts/)

Backwards compatible, but new files use doubles.

Additionally, some improvements are made to the scrubbing and frame control.

Only open issue for now, is the wheels tucking in when going at high speeds, need to check what suspension thinks is happening.