### PR TITLE
Feature/multi ghosts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "thirdparty/fmt"]
 	path = thirdparty/fmt
 	url = https://github.com/fmtlib/fmt
-[submodule "thirdparty/lodepng"]
-	path = thirdparty/lodepng
-	url = https://github.com/lvandeve/lodepng
 [submodule "thirdparty/pugixml"]
 	path = thirdparty/pugixml
 	url = https://github.com/zeux/pugixml

--- a/GhostReplay/Constants.hpp
+++ b/GhostReplay/Constants.hpp
@@ -2,9 +2,9 @@
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
 
-#define VERSION_MAJOR 1
-#define VERSION_MINOR 3
-#define VERSION_PATCH 1
+#define VERSION_MAJOR 2
+#define VERSION_MINOR 0
+#define VERSION_PATCH 0
 
 namespace Constants {
     static const char* const DisplayVersion = "v" STR(VERSION_MAJOR) "."  STR(VERSION_MINOR) "." STR(VERSION_PATCH);

--- a/GhostReplay/GhostReplay.vcxproj
+++ b/GhostReplay/GhostReplay.vcxproj
@@ -98,9 +98,6 @@
     <ClCompile Include="..\thirdparty\GTAVMenuBase\menusettings.cpp" />
     <ClCompile Include="..\thirdparty\GTAVMenuBase\menuutils.cpp" />
     <ClCompile Include="..\thirdparty\jpegsize\jpegsize.cpp" />
-    <ClCompile Include="..\thirdparty\lodepng\lodepng.cpp">
-      <WarningLevel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">TurnOffAllWarnings</WarningLevel>
-    </ClCompile>
     <ClCompile Include="..\thirdparty\pugixml\src\pugixml.cpp" />
     <ClCompile Include="Blip.cpp" />
     <ClCompile Include="Compatibility.cpp" />
@@ -135,7 +132,6 @@
     <ClInclude Include="..\thirdparty\GTAVMenuBase\menusettings.h" />
     <ClInclude Include="..\thirdparty\GTAVMenuBase\menuutils.h" />
     <ClInclude Include="..\thirdparty\jpegsize\jpegsize.h" />
-    <ClInclude Include="..\thirdparty\lodepng\lodepng.h" />
     <ClInclude Include="..\thirdparty\pugixml\src\pugiconfig.hpp" />
     <ClInclude Include="..\thirdparty\pugixml\src\pugixml.hpp" />
     <ClInclude Include="Blip.hpp" />

--- a/GhostReplay/GhostReplay.vcxproj.filters
+++ b/GhostReplay/GhostReplay.vcxproj.filters
@@ -63,9 +63,6 @@
     <ClCompile Include="..\thirdparty\jpegsize\jpegsize.cpp">
       <Filter>ThirdParty\jpegsize</Filter>
     </ClCompile>
-    <ClCompile Include="..\thirdparty\lodepng\lodepng.cpp">
-      <Filter>ThirdParty\lodepng</Filter>
-    </ClCompile>
     <ClCompile Include="..\thirdparty\pugixml\src\pugixml.cpp">
       <Filter>ThirdParty\pugixml</Filter>
     </ClCompile>
@@ -97,9 +94,6 @@
     </Filter>
     <Filter Include="Menu %28Generic%29">
       <UniqueIdentifier>{a63f42e5-fef3-4537-a62b-1ead2e96c87a}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="ThirdParty\lodepng">
-      <UniqueIdentifier>{863ebd5f-8818-4df8-b276-9760c2402902}</UniqueIdentifier>
     </Filter>
     <Filter Include="ThirdParty\jpegsize">
       <UniqueIdentifier>{cbe1c59b-26ff-481e-9d42-12ce1323a4b2}</UniqueIdentifier>
@@ -181,9 +175,6 @@
     <ClInclude Include="Image.hpp" />
     <ClInclude Include="..\thirdparty\jpegsize\jpegsize.h">
       <Filter>ThirdParty\jpegsize</Filter>
-    </ClInclude>
-    <ClInclude Include="..\thirdparty\lodepng\lodepng.h">
-      <Filter>ThirdParty\lodepng</Filter>
     </ClInclude>
     <ClInclude Include="..\thirdparty\pugixml\src\pugixml.hpp">
       <Filter>ThirdParty\pugixml</Filter>

--- a/GhostReplay/Image.cpp
+++ b/GhostReplay/Image.cpp
@@ -3,58 +3,163 @@
 #include "Util/Logger.hpp"
 #include "Util/String.hpp"
 
-
 #include <jpegsize/jpegsize.h>
 #include <lodepng/lodepng.h>
 
 #include <filesystem>
-
+#include <fstream>
 
 namespace fs = std::filesystem;
 
-namespace {
-    const std::vector<std::string> allowedExtensions{ ".png", ".jpg", ".jpeg" };
-}
+std::optional<std::pair<uint32_t, uint32_t>> Img::GetIMGDimensions(const std::string& path) {
+    std::string ext = Util::to_lower(fs::path(path).extension().string());
 
-const std::vector<std::string>& Img::GetAllowedExtensions() {
-    return allowedExtensions;
-}
+    std::optional<std::pair<uint32_t, uint32_t>> result;
 
-bool Img::GetIMGDimensions(std::string file, unsigned* width, unsigned* height) {
-    auto ext = Util::to_lower(fs::path(file).extension().string());
     if (ext == ".png")
-        return GetPNGDimensions(file, width, height);
-    if (ext == ".jpg" || ext == ".jpeg")
-        return GetJPGDimensions(file, width, height);
-    return false;
+        result = GetPNGDimensions(path);
+    else if (ext == ".jpg" || ext == ".jpeg")
+        result = GetJPGDimensions(path);
+    else if (ext == ".webp")
+        result = GetWebPDimensions(path);
+    else
+        return {};
+
+    return result;
 }
 
-bool Img::GetPNGDimensions(std::string file, unsigned* width, unsigned* height) {
-    std::vector<unsigned char> image;
-    unsigned error = lodepng::decode(image, *width, *height, file);
-    if (error) {
-        logger.Write(ERROR, "[Img] PNG error: %s: %s", std::to_string(error).c_str(), lodepng_error_text(error));
-        return false;
+std::optional<std::pair<uint32_t, uint32_t>> Img::GetPNGDimensions(const std::string& path) {
+    const uint64_t pngSig = 0x89504E470D0A1A0A;
+
+    std::ifstream img(path, std::ios::binary);
+
+    if (!img.good()) {
+        logger.Write(ERROR, "[IMG]: %s failed to open", path.c_str());
+        return {};
     }
-    return true;
+
+    uint64_t imgSig = 0x0;
+
+    img.seekg(0);
+    img.read((char*)&imgSig, sizeof(uint64_t));
+
+    imgSig = _byteswap_uint64(imgSig);
+
+    if (imgSig == pngSig) {
+        uint32_t w, h;
+
+        img.seekg(16);
+        img.read((char*)&w, 4);
+        img.read((char*)&h, 4);
+
+        w = _byteswap_ulong(w);
+        h = _byteswap_ulong(h);
+
+        return { {w, h} };
+    }
+
+    logger.Write(ERROR, "[IMG]: %s not a PNG file, sig: 0x%16X", path.c_str(), imgSig);
+    return {};
 }
 
-bool Img::GetJPGDimensions(std::string file, unsigned* width, unsigned* height) {
+std::optional<std::pair<uint32_t, uint32_t>> Img::GetJPGDimensions(const std::string& path) {
     FILE* image = nullptr;
 
-    errno_t err = fopen_s(&image, file.c_str(), "rb"); // open JPEG image file
+    errno_t err = fopen_s(&image, path.c_str(), "rb");  // open JPEG image file
     if (!image || err) {
-        logger.Write(ERROR, "[Img] JPEG error: %s: Failed to open file", fs::path(file).filename().string().c_str());
-        return false;
+        logger.Write(ERROR, "[IMG]: %s: Failed to open file", fs::path(path).filename().string().c_str());
+        if (image)
+            fclose(image);
+        return {};
     }
     int w, h;
     int result = scanhead(image, &w, &h);
+    fclose(image);
+
     if (result == 1) {
-        *width = w;
-        *height = h;
-        return true;
+        return { {w, h} };
     }
-    logger.Write(ERROR, "[Img] JPEG error: %s: getting size failed.",
-                 fs::path(file).filename().string().c_str());
-    return false;
+    else {
+        return {};
+    }
+}
+
+std::optional<std::pair<uint32_t, uint32_t>> Img::GetWebPDimensions(const std::string& path) {
+    const uint32_t riffSig = 'RIFF';
+    const uint32_t webpSig = 'WEBP';
+
+    std::ifstream img(path, std::ios::binary);
+
+    if (!img.good()) {
+        logger.Write(ERROR, "[IMG]: %s failed to open", path.c_str());
+        return {};
+    }
+
+    uint32_t imgRiffSig = 0x0;
+    uint32_t imgWebPSig = 0x0;
+
+    img.seekg(0);
+    img.read((char*)&imgRiffSig, sizeof(uint32_t));
+    imgRiffSig = _byteswap_ulong(imgRiffSig);
+
+    img.seekg(2 * sizeof(uint32_t));
+    img.read((char*)&imgWebPSig, sizeof(uint32_t));
+    imgWebPSig = _byteswap_ulong(imgWebPSig);
+
+    if (imgRiffSig == riffSig && imgWebPSig == webpSig) {
+        uint32_t vp8Sig = 0x0;
+
+        img.seekg(3 * sizeof(uint32_t));
+        img.read((char*)&vp8Sig, sizeof(uint32_t));
+        vp8Sig = _byteswap_ulong(vp8Sig);
+
+        switch (vp8Sig) {
+        case 'VP8 ': {
+            uint8_t sigBytes[3] = { 0x0, 0x0, 0x0 };
+            img.seekg(0x17);
+            img.read((char*)sigBytes, 3);
+            if (sigBytes[0] != 0x9D || sigBytes[1] != 0x01 || sigBytes[2] != 0x2A) {
+                logger.Write(ERROR, "[IMG]: %s failed to find VP8 (Lossy) signature bytes, got 0x%02X 0x%02X 0x%02X",
+                    path.c_str(), sigBytes[0], sigBytes[1], sigBytes[2]);
+                return {};
+            }
+
+            uint16_t w = 0x0;
+            uint16_t h = 0x0;
+
+            img.read((char*)&w, 2);
+            img.read((char*)&h, 2);
+
+            return { {w, h} };
+        }
+        case 'VP8L': {
+            uint8_t sigByte = 0x0;
+            img.seekg(5 * sizeof(uint32_t));
+            img.read((char*)&sigByte, 1);
+            if (sigByte != 0x2F) {
+                logger.Write(ERROR, "[IMG]: %s failed to find VP8 (Lossless) signature byte, got 0x%02X",
+                    path.c_str(), sigByte);
+                return {};
+            }
+
+            uint32_t wh = 0x0;
+
+            img.read((char*)&wh, 4);
+            wh = wh & 0x0FFFFFFF;
+
+            uint16_t w = wh & 0x3FFF;
+            uint16_t h = (wh >> 14) & 0x3FFF;
+            return { {w + 1, h + 1} };
+        }
+        default:
+            logger.Write(ERROR, "[IMG]: %s unrecognized WebP format. FourCC: 0x%04X",
+                path.c_str(), vp8Sig);
+            return {};
+        }
+    }
+    else {
+        logger.Write(ERROR, "[IMG]: %s not a WebP file. RIFF (0x%04X): 0x%04X, WEBP (0x%04X): 0x%04X",
+            path.c_str(), riffSig, imgRiffSig, webpSig, imgWebPSig);
+        return {};
+    }
 }

--- a/GhostReplay/Image.cpp
+++ b/GhostReplay/Image.cpp
@@ -4,7 +4,6 @@
 #include "Util/String.hpp"
 
 #include <jpegsize/jpegsize.h>
-#include <lodepng/lodepng.h>
 
 #include <filesystem>
 #include <fstream>

--- a/GhostReplay/Image.hpp
+++ b/GhostReplay/Image.hpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <optional>
 
 class CImage {
 public:
@@ -19,8 +20,9 @@ public:
 };
 
 namespace Img {
-    const std::vector<std::string>& GetAllowedExtensions();
-    bool GetIMGDimensions(std::string file, unsigned* width, unsigned* height);
-    bool GetPNGDimensions(std::string file, unsigned* width, unsigned* height);
-    bool GetJPGDimensions(std::string file, unsigned* width, unsigned* height);
+    std::optional<std::pair<uint32_t, uint32_t>> GetIMGDimensions(const std::string& path);
+
+    std::optional<std::pair<uint32_t, uint32_t>> GetPNGDimensions(const std::string& path);
+    std::optional<std::pair<uint32_t, uint32_t>> GetJPGDimensions(const std::string& path);
+    std::optional<std::pair<uint32_t, uint32_t>> GetWebPDimensions(const std::string& path);
 }

--- a/GhostReplay/ReplayMenu.cpp
+++ b/GhostReplay/ReplayMenu.cpp
@@ -107,13 +107,7 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
 
         mbCtx.MenuOption("Ghost controls", "ghostoptionsmenu");
 
-        bool replaying = false;
-        for (const auto& replayVehicle : context.GetReplayVehicles()) {
-            if (replayVehicle->GetReplayState() != EReplayState::Idle) {
-                replaying = true;
-                break;
-            }
-        }
+        bool replaying = context.GetReplayState() != EReplayState::Idle;
         std::string replayAbortOption = replaying ? "Cancel playing ghosts" : "~m~Cancel playing ghosts";
         std::vector<std::string> replayAbortDetail;
         if (replaying) {
@@ -561,17 +555,7 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
             const double scrubDist = GetSettings().Replay.ScrubDistanceSeconds * 1000.0; // milliseconds
             const auto& activeReplays = context.ActiveReplays();
             const auto& replayVehicles = context.GetReplayVehicles();
-            EReplayState replayState = EReplayState::Idle;
-
-            for (auto& replayVehicle : replayVehicles) {
-                if (replayVehicle->GetReplayState() == EReplayState::Playing) {
-                    replayState = EReplayState::Playing;
-                    break;
-                }
-                if (replayVehicle->GetReplayState() == EReplayState::Paused) {
-                    replayState = EReplayState::Paused;
-                }
-            }
+            EReplayState replayState = context.GetReplayState();
 
             std::string replayStateName;
             switch (replayState) {
@@ -656,13 +640,7 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
                     { "Frame controls are only available with 1 active replay." });
             }
 
-            bool replaying = false;
-            for (const auto& replayVehicle : context.GetReplayVehicles()) {
-                if (replayVehicle->GetReplayState() != EReplayState::Idle) {
-                    replaying = true;
-                    break;
-                }
-            }
+            bool replaying = replayState != EReplayState::Idle;
             std::string replayAbortOption = replaying ? "Stop playback" : "~m~Stop playback";
             if (mbCtx.Option(replayAbortOption)) {
                 if (replaying)

--- a/GhostReplay/ReplayMenu.cpp
+++ b/GhostReplay/ReplayMenu.cpp
@@ -145,20 +145,6 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
         }
 
         mbCtx.MenuOption("Unsaved runs", "unsavedrunsmenu");
-
-        if (mbCtx.Option("Refresh tracks and ghosts", 
-            { "Refresh tracks and ghosts if they are changed outside the script." } )) {
-            context.StopRecording();
-            context.StopAllReplays();
-            context.ClearSelectedReplays();
-
-            GhostReplay::LoadTracks();
-            GhostReplay::LoadARSTracks();
-            GhostReplay::LoadReplays();
-            GhostReplay::LoadTrackImages();
-            UI::Notify("Tracks and replays refreshed", false);
-        }
-
         mbCtx.MenuOption("Settings", "settingsmenu");
     });
 
@@ -738,6 +724,19 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
 
         mbCtx.MenuOption("Recording settings", "recordsettingsmenu");
         mbCtx.MenuOption("Advanced ghost settings", "advghostsettingsmenu");
+
+        if (mbCtx.Option("Refresh tracks and ghosts",
+            { "Refresh tracks and ghosts if they are changed outside the script." })) {
+            context.StopRecording();
+            context.StopAllReplays();
+            context.ClearSelectedReplays();
+
+            GhostReplay::LoadTracks();
+            GhostReplay::LoadARSTracks();
+            GhostReplay::LoadReplays();
+            GhostReplay::LoadTrackImages();
+            formattedTrackData.clear();
+        }
     });
 
     /* mainmenu -> settingsmenu -> recordsettingsmenu */

--- a/GhostReplay/ReplayMenu.cpp
+++ b/GhostReplay/ReplayMenu.cpp
@@ -536,6 +536,12 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
             MenuUtils::GetKbFloat, { "Ghost offset. Positive is in front, negative is behind, in seconds." });
         if (offsetChanged) {
             GetSettings().Replay.OffsetSeconds = static_cast<double>(offset);
+            auto newTime = context.GetReplayProgress() + offset * 1000.0;
+            for (auto& replayVehicle : context.GetReplayVehicles()) {
+                if (replayVehicle->GetReplayState() != EReplayState::Idle)
+                    replayVehicle->SetReplayTime(newTime);
+            }
+
         }
 
         const std::vector<std::string> replayAlphaDescr{

--- a/GhostReplay/ReplayMenu.cpp
+++ b/GhostReplay/ReplayMenu.cpp
@@ -449,6 +449,11 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
             if (triggerBreak)
                 break;
         }
+
+        if (mbCtx.Option("Deselect all replays")) {
+            context.StopAllReplays();
+            context.ClearSelectedReplays();
+        }
     });
 
     /* mainmenu -> unsavedrunsmenu */

--- a/GhostReplay/ReplayMenu.cpp
+++ b/GhostReplay/ReplayMenu.cpp
@@ -532,8 +532,8 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
         mbCtx.Subtitle("");
 
         float offset = static_cast<float>(GetSettings().Replay.OffsetSeconds);
-        bool offsetChanged = mbCtx.FloatOptionCb("Offset (seconds)", offset, -60.0f, 60.0f, 0.05f,
-            MenuUtils::GetKbFloat, { "Ghost offset. Positive is in front, negative is behind." });
+        bool offsetChanged = mbCtx.FloatOptionCb("Offset", offset, -60.0f, 60.0f, 0.05f,
+            MenuUtils::GetKbFloat, { "Ghost offset. Positive is in front, negative is behind, in seconds." });
         if (offsetChanged) {
             GetSettings().Replay.OffsetSeconds = static_cast<double>(offset);
         }
@@ -566,7 +566,7 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
             mbCtx.Option("~m~Replay controls unavailable", { "Select a track and a replay." });
         }
         else {
-            const double scrubDist = 1000.0; // milliseconds
+            const double scrubDist = GetSettings().Replay.ScrubDistanceSeconds * 1000.0; // milliseconds
             const auto& activeReplays = context.ActiveReplays();
             const auto& replayVehicles = context.GetReplayVehicles();
             EReplayState replayState = EReplayState::Idle;
@@ -766,6 +766,15 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
 
         mbCtx.BoolOption("Auto-load quickest ghost", GetSettings().Replay.AutoLoadGhost, 
             { "Automatically loads the quickest ghost lap when a track is selected, for that specific car model." });
+
+        float scrubDist = static_cast<float>(GetSettings().Replay.ScrubDistanceSeconds);
+        bool scrubDistChanged = mbCtx.FloatOptionCb("Scrub distance", scrubDist, 0.010f, 60.0f, 0.010f,
+            MenuUtils::GetKbFloat,
+            { "How far to skip back and forth, in seconds.",
+              "Hint: Press enter/select to manually input value." });
+        if (scrubDistChanged) {
+            GetSettings().Replay.ScrubDistanceSeconds = static_cast<double>(scrubDist);
+        }
 
         std::string fallbackOpt =
             fmt::format("Fallback vehicle model: {}", GetSettings().Replay.FallbackModel);

--- a/GhostReplay/ReplayScript.cpp
+++ b/GhostReplay/ReplayScript.cpp
@@ -539,12 +539,9 @@ double CReplayScript::GetSlowestActiveReplay() {
 
 void CReplayScript::TogglePause(bool pause) {
     bool anyDriving = mGlobalReplayState != EReplayState::Idle;
-
     for (auto& replayVehicle : mReplayVehicles) {
-        if (!anyDriving) {
-            replayVehicle->TogglePause(pause);
-        }
-        else if (replayVehicle->GetReplayState() != EReplayState::Idle) {
+        if (!anyDriving ||
+            replayVehicle->GetReplayState() != EReplayState::Idle) {
             replayVehicle->TogglePause(pause);
         }
     }

--- a/GhostReplay/ReplayScript.cpp
+++ b/GhostReplay/ReplayScript.cpp
@@ -68,6 +68,7 @@ void CReplayScript::StopAllReplays() {
 }
 
 void CReplayScript::SetTrack(const std::string& trackName) {
+    StopAllReplays();
     ClearSelectedReplays();
     mCompatibleReplays.clear();
     clearPtfx();

--- a/GhostReplay/ReplayScript.cpp
+++ b/GhostReplay/ReplayScript.cpp
@@ -561,7 +561,7 @@ void CReplayScript::ScrubBackward(double step) {
 
     for (auto& replayVehicle : mReplayVehicles) {
         if (replayVehicle->GetReplayState() != EReplayState::Idle)
-            replayVehicle->SetReplayTime(mReplayCurrentTime);
+            replayVehicle->SetReplayTime(mReplayCurrentTime + mSettings.Replay.OffsetSeconds * 1000.0);
     }
 }
 
@@ -579,7 +579,7 @@ void CReplayScript::ScrubForward(double step) {
 
     for (auto& replayVehicle : mReplayVehicles) {
         if (replayVehicle->GetReplayState() != EReplayState::Idle)
-            replayVehicle->SetReplayTime(mReplayCurrentTime);
+            replayVehicle->SetReplayTime(mReplayCurrentTime + mSettings.Replay.OffsetSeconds * 1000.0);
     }
 }
 
@@ -699,9 +699,10 @@ void CReplayScript::updateReplay() {
         mReplayCurrentTime = gameTime - mReplayStartTime;
     }
 
+    double replayTime = mReplayCurrentTime + mSettings.Replay.OffsetSeconds * 1000.0;
     bool anyGhostLapTriggered = false;
     for (const auto& replayVehicle : mReplayVehicles)
-        anyGhostLapTriggered |= replayVehicle->UpdatePlayback(mReplayCurrentTime, startPassedThisTick, finishPassedThisTick);
+        anyGhostLapTriggered |= replayVehicle->UpdatePlayback(replayTime, startPassedThisTick, finishPassedThisTick);
 
     if (anyGhostLapTriggered) {
         mReplayStartTime = gameTime;

--- a/GhostReplay/ReplayScript.cpp
+++ b/GhostReplay/ReplayScript.cpp
@@ -30,6 +30,7 @@ CReplayScript::CReplayScript(
     std::vector<CImage>& trackImages,
     std::vector<CTrackData>& arsTracks)
     : mCurrentTime(static_cast<double>(MISC::GET_GAME_TIMER()))
+    , mGlobalReplayState(EReplayState::Idle)
     , mSettings(settings)
     , mReplays(replays)
     , mCompatibleReplays()

--- a/GhostReplay/ReplayScript.cpp
+++ b/GhostReplay/ReplayScript.cpp
@@ -391,6 +391,16 @@ void CReplayScript::ActivatePassengerMode() {
         return;
     }
 
+    CReplayVehicle* passengerVehicle = mPassengerVehicle;
+    if (passengerVehicle == nullptr) {
+        passengerVehicle = mReplayVehicles[0].get();
+    }
+    if (mGlobalReplayState != EReplayState::Idle &&
+        passengerVehicle->GetReplayState() == EReplayState::Idle) {
+        UI::Notify("Can't enter passenger mode, vehicle is not driving.");
+        return;
+    }
+
     StopRecording();
 
     Ped playerPed = PLAYER::PLAYER_PED_ID();
@@ -504,8 +514,17 @@ void CReplayScript::PassengerVehicleNext() {
     else
         mPassengerVehicle = std::next(selectedVehicle)->get();
 
-    if (mPassengerModeActive)
+    if (mPassengerModeActive) {
+        if (mGlobalReplayState != EReplayState::Idle &&
+            mPassengerVehicle->GetReplayState() == EReplayState::Idle) {
+            UI::Notify("Can't switch to vehicle, vehicle is not driving.");
+            if (selectedVehicle != mReplayVehicles.end()) {
+                DeactivatePassengerMode(selectedVehicle->get()->GetVehicle());
+            }
+            return;
+        }
         setPlayerIntoVehicleFreeSeat(mPassengerVehicle->GetVehicle());
+    }
 }
 
 void CReplayScript::PassengerVehiclePrev() {
@@ -521,8 +540,17 @@ void CReplayScript::PassengerVehiclePrev() {
     else
         mPassengerVehicle = std::prev(selectedVehicle)->get();
 
-    if (mPassengerModeActive)
+    if (mPassengerModeActive) {
+        if (mGlobalReplayState != EReplayState::Idle &&
+            mPassengerVehicle->GetReplayState() == EReplayState::Idle) {
+            UI::Notify("Can't switch to vehicle, vehicle is not driving.");
+            if (selectedVehicle != mReplayVehicles.end()) {
+                DeactivatePassengerMode(selectedVehicle->get()->GetVehicle());
+            }
+            return;
+        }
         setPlayerIntoVehicleFreeSeat(mPassengerVehicle->GetVehicle());
+    }
 }
 
 CReplayVehicle* CReplayScript::GetPassengerVehicle() {

--- a/GhostReplay/ReplayScript.cpp
+++ b/GhostReplay/ReplayScript.cpp
@@ -714,7 +714,10 @@ void CReplayScript::updateReplay() {
 
     mLastPos = nowPos;
 
-    updateRecord(gameTime, !inGhostVehicle && startPassedThisTick, !inGhostVehicle && finishPassedThisTick);
+    updateRecord(
+        gameTime,
+        !inGhostVehicle && startPassedThisTick,
+        !inGhostVehicle && finishPassedThisTick);
 
     if (!anyPaused && anyDriving) {
         mReplayCurrentTime = gameTime - mReplayStartTime;
@@ -722,8 +725,12 @@ void CReplayScript::updateReplay() {
 
     double replayTime = mReplayCurrentTime + mSettings.Replay.OffsetSeconds * 1000.0;
     bool anyGhostLapTriggered = false;
-    for (const auto& replayVehicle : mReplayVehicles)
-        anyGhostLapTriggered |= replayVehicle->UpdatePlayback(replayTime, startPassedThisTick, finishPassedThisTick);
+    for (const auto& replayVehicle : mReplayVehicles) {
+        anyGhostLapTriggered |= replayVehicle->UpdatePlayback(
+            replayTime,
+            !inGhostVehicle && startPassedThisTick,
+            !inGhostVehicle && finishPassedThisTick);
+    }
 
     if (anyGhostLapTriggered) {
         mReplayStartTime = gameTime;

--- a/GhostReplay/ReplayScript.hpp
+++ b/GhostReplay/ReplayScript.hpp
@@ -46,8 +46,8 @@ public:
         return mUnsavedRuns;
     }
 
-    CReplayData* ActiveReplay() const {
-        return mActiveReplay;
+    std::vector<CReplayData*> ActiveReplays() const {
+        return mActiveReplays;
     }
 
     CTrackData* ActiveTrack() const {
@@ -62,16 +62,7 @@ public:
         mScriptMode = mode;
     }
 
-    EReplayState GetReplayState() {
-        if (mReplayVehicle)
-            return mReplayVehicle->GetReplayState();
-        return EReplayState::Idle;
-    }
-
-    void StopReplay() {
-        if (mReplayVehicle)
-            mReplayVehicle->StopReplay();
-    }
+    void StopAllReplays();
 
     bool IsRecording() {
         return mRecordState == ERecordState::Recording;
@@ -82,14 +73,14 @@ public:
         mCurrentRun = CReplayData("");
     }
 
-    Vehicle GetReplayVehicle() {
-        if (mReplayVehicle)
-            return mReplayVehicle->GetVehicle();
-        return 0;
+    const std::vector<std::unique_ptr<CReplayVehicle>>& GetReplayVehicles() {
+        return mReplayVehicles;
     }
 
     void SetTrack(const std::string& trackName);
-    void SetReplay(const std::string& replayName, unsigned long long timestamp = 0);
+    void SelectReplay(const std::string& replayName, unsigned long long timestamp);
+    void DeselectReplay(const std::string& replayName, unsigned long long timestamp);
+    void ClearSelectedReplays();
     void ClearUnsavedRuns();
     std::vector<CReplayData>::const_iterator EraseUnsavedRun(std::vector<CReplayData>::const_iterator runIt);
 
@@ -112,6 +103,7 @@ public:
 
     // Playback control
     double GetReplayProgress();
+    double GetSlowestActiveReplay();
     void TogglePause(bool pause);
     void ScrubBackward(double step);
     void ScrubForward(double step);
@@ -132,6 +124,10 @@ protected:
     void startRecord(double gameTime, Vehicle vehicle);
     bool saveNode(double gameTime, SReplayNode& node, Vehicle vehicle, bool firstNode);
     void finishRecord(bool saved, const SReplayNode& node);
+    CReplayData* getFastestActiveReplay();
+    CReplayData* getSlowestActiveReplay();
+    void updateSlowestReplay();
+
     void clearPtfx();
     void createPtfx(const CTrackData& trackData);
     void clearTrackBlips();
@@ -149,7 +145,7 @@ protected:
     std::vector<CImage>& mTrackImages;
     std::vector<CTrackData>& mArsTracks;
 
-    CReplayData* mActiveReplay;
+    std::vector<CReplayData*> mActiveReplays;
     CTrackData* mActiveTrack;
 
     std::unique_ptr<CWrappedBlip> mStartBlip;
@@ -161,7 +157,10 @@ protected:
 
     Vector3 mLastPos;
 
-    std::unique_ptr<CReplayVehicle> mReplayVehicle;
+    std::vector<std::unique_ptr<CReplayVehicle>> mReplayVehicles;
+    double mReplayStartTime = 0.0;
+    double mReplayCurrentTime = 0.0;
+    double mSlowestReplayTime = 0.0;
 
     std::vector<CReplayData> mUnsavedRuns;
     CReplayData mCurrentRun;

--- a/GhostReplay/ReplayScript.hpp
+++ b/GhostReplay/ReplayScript.hpp
@@ -100,6 +100,9 @@ public:
     void DeactivatePassengerMode();
     void DeactivatePassengerMode(Vehicle vehicle);
     bool IsPassengerModeActive() { return mPassengerModeActive; }
+    void PassengerVehicleNext();
+    void PassengerVehiclePrev();
+    CReplayVehicle* GetPassengerVehicle();
 
     // Playback control
     double GetReplayProgress();
@@ -136,6 +139,8 @@ protected:
     void updateSteppedTime();
     double getSteppedTime();
 
+    void setPlayerIntoVehicleFreeSeat(Vehicle vehicle);
+
     double mCurrentTime;
 
     const CScriptSettings& mSettings;
@@ -168,6 +173,7 @@ protected:
     std::vector<int> mPtfxHandles;
 
     bool mPassengerModeActive = false;
-    Vehicle mPassengerModePlayerVehicle;
+    Vehicle mPassengerModePlayerVehicle = 0;
     bool mPassengerModPlayerVehicleManagedByThisScript = false;
+    CReplayVehicle* mPassengerVehicle = nullptr;
 };

--- a/GhostReplay/ReplayScript.hpp
+++ b/GhostReplay/ReplayScript.hpp
@@ -105,6 +105,9 @@ public:
     CReplayVehicle* GetPassengerVehicle();
 
     // Playback control
+
+    // Gets the highest replay state of all ghosts.
+    EReplayState GetReplayState() { return mGlobalReplayState; }
     double GetReplayProgress();
     double GetSlowestActiveReplay();
     void TogglePause(bool pause);
@@ -120,6 +123,7 @@ public:
     void TeleportToTrack(const CTrackData& trackData);
 
 protected:
+    void updateGlobalStates();
     void updateReplay();
     void updateRecord(double gameTime, bool startPassedThisTick, bool finishPassedThisTick);
     void updateTrackDefine();
@@ -142,6 +146,8 @@ protected:
     void setPlayerIntoVehicleFreeSeat(Vehicle vehicle);
 
     double mCurrentTime;
+
+    EReplayState mGlobalReplayState;
 
     const CScriptSettings& mSettings;
     std::vector<std::shared_ptr<CReplayData>>& mReplays;

--- a/GhostReplay/ReplayScript.hpp
+++ b/GhostReplay/ReplayScript.hpp
@@ -144,6 +144,8 @@ protected:
     double getSteppedTime();
 
     void setPlayerIntoVehicleFreeSeat(Vehicle vehicle);
+    // Called by ghost instance on cleanup when instance replay is reset, vehicle is its own vehicle.
+    void ghostCleanup(Vehicle vehicle);
 
     double mCurrentTime;
 

--- a/GhostReplay/ReplayVehicle.cpp
+++ b/GhostReplay/ReplayVehicle.cpp
@@ -54,8 +54,10 @@ bool CReplayVehicle::UpdatePlayback(double replayTime, bool startPassedThisTick,
             break;
         }
         case EReplayState::Playing: {
-            // The time that has elapsed from the viewpoint of the replay.
-            replayTime += mSettings.Replay.OffsetSeconds * 1000.0;
+            if (replayTime < 0.0) {
+                showNode(0.0, mActiveReplay->Nodes.begin(), mActiveReplay->Nodes.begin());
+                break;
+            }
 
             // Find the node where the timestamp is larger than the current virtual timestamp (replayTime).
             auto nodeNext = std::upper_bound(mLastNode, mActiveReplay->Nodes.end(), SReplayNode{ replayTime });
@@ -68,8 +70,15 @@ bool CReplayVehicle::UpdatePlayback(double replayTime, bool startPassedThisTick,
             }
 
             // Update the node passed, if progressed past it.
-            if (mLastNode != std::prev(nodeNext))
-                mLastNode = std::prev(nodeNext);
+            if (mLastNode != std::prev(nodeNext)) {
+                if (nodeNext != mActiveReplay->Nodes.begin()) {
+                    mLastNode = std::prev(nodeNext);
+                }
+                else {
+                    mLastNode = nodeNext;
+                    nodeNext = std::next(nodeNext);
+                }
+            }
 
             // Show the node, with <nodePrev> <now> <nodeNext>.
             showNode(replayTime, mLastNode, nodeNext);

--- a/GhostReplay/ReplayVehicle.cpp
+++ b/GhostReplay/ReplayVehicle.cpp
@@ -26,18 +26,20 @@ CReplayVehicle::~CReplayVehicle() {
         resetReplay();
 }
 
-void CReplayVehicle::UpdatePlayback(double gameTime, bool startPassedThisTick, bool finishPassedThisTick) {
+bool CReplayVehicle::UpdatePlayback(double replayTime, bool startPassedThisTick, bool finishPassedThisTick) {
+    bool startedReplayThisTick = false;
     if (!mActiveReplay) {
         mReplayState = EReplayState::Idle;
         resetReplay();
-        return;
+        return startedReplayThisTick;
     }
 
     switch (mReplayState) {
         case EReplayState::Idle: {
             if (startPassedThisTick) {
                 mReplayState = EReplayState::Playing;
-                startReplay(gameTime);
+                startReplay();
+                startedReplayThisTick = true;
             }
             break;
         }
@@ -45,14 +47,14 @@ void CReplayVehicle::UpdatePlayback(double gameTime, bool startPassedThisTick, b
             if (mActiveReplay && mLastNode == mActiveReplay->Nodes.end()) {
                 logger.Write(DEBUG, "Updating currentNode to activeReplay begin");
                 mLastNode = mActiveReplay->Nodes.begin();
-                startReplay(gameTime);
+                startReplay();
+                startedReplayThisTick = true;
             }
             showNode(mLastNode->Timestamp, mLastNode, mLastNode);
             break;
         }
         case EReplayState::Playing: {
             // The time that has elapsed from the viewpoint of the replay.
-            auto replayTime = gameTime - mReplayStart;
             replayTime += mSettings.Replay.OffsetSeconds * 1000.0;
 
             // Find the node where the timestamp is larger than the current virtual timestamp (replayTime).
@@ -71,20 +73,25 @@ void CReplayVehicle::UpdatePlayback(double gameTime, bool startPassedThisTick, b
 
             // Show the node, with <nodePrev> <now> <nodeNext>.
             showNode(replayTime, mLastNode, nodeNext);
-
-            // On a faster player lap, the current replay is nuked and this doesn't run, but better to
-            // not rely on that behavior and have this here anyway, in case that part changes.
-            if (finishPassedThisTick) {
-                mReplayState = EReplayState::Idle;
-                resetReplay();
-                if (startPassedThisTick) {
-                    mReplayState = EReplayState::Playing;
-                    startReplay(gameTime);
-                }
-            }
             break;
         }
     }
+
+    // Always abort a paused or slower ghost lap when the player has finished.
+    // And restart it again, if the start was passed in the same tick.
+    if (mReplayState != EReplayState::Idle) {
+        if (finishPassedThisTick) {
+            mReplayState = EReplayState::Idle;
+            resetReplay();
+            if (startPassedThisTick) {
+                mReplayState = EReplayState::Playing;
+                startReplay();
+                startedReplayThisTick = true;
+            }
+        }
+    }
+
+    return startedReplayThisTick;
 }
 
 double CReplayVehicle::GetReplayProgress() {
@@ -94,65 +101,39 @@ double CReplayVehicle::GetReplayProgress() {
     return 0;
 }
 
-void CReplayVehicle::TogglePause(bool pause, double gameTime) {
+void CReplayVehicle::TogglePause(bool pause) {
     if (mReplayState == EReplayState::Idle) {
-        startReplay(gameTime);
+        startReplay();
     }
     if (pause) {
         mReplayState = EReplayState::Paused;
     }
     else {
         mReplayState = EReplayState::Playing;
-        double offset = 0.0;
-        if (mActiveReplay && mLastNode != mActiveReplay->Nodes.end()) {
-            offset = mLastNode->Timestamp;
-        }
-        mReplayStart = gameTime - offset;
     }
 }
 
-void CReplayVehicle::ScrubBackward(double step) {
-    if (mActiveReplay && mLastNode != mActiveReplay->Nodes.end()) {
-        bool wouldSkipPastBegin = mLastNode->Timestamp < step;
-        auto minMillis = wouldSkipPastBegin ?
-            mLastNode->Timestamp :
-            step;
+void CReplayVehicle::SetReplayTime(double replayTime) {
+    // Find node with smaller timestamp than our replayTime
+    auto nodeCurr = std::lower_bound(
+        mActiveReplay->Nodes.begin(),
+        mActiveReplay->Nodes.end(),
+        SReplayNode{ replayTime });
 
-        auto replayTime = mLastNode->Timestamp - minMillis;
-        auto nodeCurr = std::lower_bound(mActiveReplay->Nodes.begin(), mLastNode, SReplayNode{ replayTime });
-
-        // Step is smaller than delta-time, so just go to the previous frame.
-        if (nodeCurr != mActiveReplay->Nodes.begin() && nodeCurr == mLastNode) {
-            FramePrev();
+    // Allow ghost to end when scrubbing when not paused
+    if (mReplayState == EReplayState::Playing) {
+        // The ghost has reached the end of the recording
+        if (nodeCurr == mActiveReplay->Nodes.end() || std::next(nodeCurr) == mActiveReplay->Nodes.end()) {
+            mReplayState = EReplayState::Idle;
+            resetReplay();
             return;
         }
-
-        mLastNode = nodeCurr;
-        mReplayStart += minMillis;
     }
-}
 
-void CReplayVehicle::ScrubForward(double step) {
-    if (mActiveReplay && mLastNode != mActiveReplay->Nodes.end()) {
-        bool wouldSkipPastEnd = mLastNode->Timestamp + step > mActiveReplay->Nodes.back().Timestamp;
-        auto minMillis = wouldSkipPastEnd ?
-            mActiveReplay->Nodes.back().Timestamp - mLastNode->Timestamp :
-            step;
-
-        auto replayTime = mLastNode->Timestamp + minMillis;
-        auto nodeCurr = std::upper_bound(mLastNode, mActiveReplay->Nodes.end(), SReplayNode{ replayTime });
-        if (nodeCurr != mActiveReplay->Nodes.begin()) {
-            nodeCurr = std::prev(nodeCurr);
-        }
-
-        // Step is smaller than delta-time, so just go to the next frame.
-        if (std::next(nodeCurr) != mActiveReplay->Nodes.end() && nodeCurr == mLastNode) {
-            FrameNext();
-            return;
-        }
-
+    if (nodeCurr != mActiveReplay->Nodes.begin())
+        mLastNode = std::prev(nodeCurr);
+    else {
         mLastNode = nodeCurr;
-        mReplayStart -= minMillis;
     }
 }
 
@@ -175,34 +156,33 @@ uint64_t CReplayVehicle::GetFrameIndex() {
     return 0;
 }
 
-void CReplayVehicle::FramePrev() {
+double CReplayVehicle::FramePrev() {
     if (!mActiveReplay)
-        return;
+        return 0.0;
 
     if (mLastNode == mActiveReplay->Nodes.begin())
-        return;
+        return 0.0;
 
     auto prevIt = std::prev(mLastNode);
     auto delta = mLastNode->Timestamp - prevIt->Timestamp;
     mLastNode = prevIt;
-    mReplayStart += delta;
+    return delta;
 }
 
-void CReplayVehicle::FrameNext() {
+double CReplayVehicle::FrameNext() {
     if (!mActiveReplay || mLastNode == mActiveReplay->Nodes.end())
-        return;
+        return 0.0;
 
     if (std::next(mLastNode) == mActiveReplay->Nodes.end())
-        return;
+        return 0.0;
 
     auto nextIt = std::next(mLastNode);
     auto delta = nextIt->Timestamp - mLastNode->Timestamp;
     mLastNode = nextIt;
-    mReplayStart -= delta;
+    return delta;
 }
 
-void CReplayVehicle::startReplay(double gameTime) {
-    mReplayStart = gameTime;
+void CReplayVehicle::startReplay() {
     unhideVehicle();
     mLastNode = mActiveReplay->Nodes.begin();
 

--- a/GhostReplay/ReplayVehicle.hpp
+++ b/GhostReplay/ReplayVehicle.hpp
@@ -22,8 +22,10 @@ public:
     ~CReplayVehicle();
 
     Vehicle GetVehicle() { return mReplayVehicle; }
+    CReplayData* GetReplay() { return mActiveReplay; }
 
-    void UpdatePlayback(double gameTime, bool startPassedThisTick, bool finishPassedThisTick);
+    // Returns true when the replay was (re)started this tick.
+    bool UpdatePlayback(double replayTime, bool startPassedThisTick, bool finishPassedThisTick);
 
     EReplayState GetReplayState() {
         return mReplayState;
@@ -36,15 +38,14 @@ public:
 
     // Playback control
     double GetReplayProgress();
-    void TogglePause(bool pause, double gameTime);
-    void ScrubBackward(double step);
-    void ScrubForward(double step);
+    void TogglePause(bool pause);
+    void SetReplayTime(double replayTime);
 
     // Debugging playback
     uint64_t GetNumFrames();
     uint64_t GetFrameIndex();
-    void FramePrev();
-    void FrameNext();
+    double FramePrev();
+    double FrameNext();
 
 private:
     const CScriptSettings& mSettings;
@@ -54,12 +55,11 @@ private:
     std::unique_ptr<CWrappedBlip> mReplayVehicleBlip;
 
     EReplayState mReplayState;
-    double mReplayStart = 0.0;
     std::vector<SReplayNode>::iterator mLastNode;
 
     std::function<void(Vehicle)> mOnCleanup;
 
-    void startReplay(double gameTime);
+    void startReplay();
     void showNode(double replayTime,
         std::vector<SReplayNode>::iterator nodeCurr,
         std::vector<SReplayNode>::iterator nodeNext);

--- a/GhostReplay/ScriptSettings.cpp
+++ b/GhostReplay/ScriptSettings.cpp
@@ -42,6 +42,7 @@ void CScriptSettings::Load() {
     LOAD_VAL("Replay", "VehicleAlpha", Replay.VehicleAlpha);
     LOAD_VAL("Replay", "ForceLights", Replay.ForceLights);
 
+    LOAD_VAL("Replay", "ScrubDistanceSeconds", Replay.ScrubDistanceSeconds);
     LOAD_VAL("Replay", "FallbackModel", Replay.FallbackModel);
     LOAD_VAL("Replay", "ForceFallbackModel", Replay.ForceFallbackModel);
     LOAD_VAL("Replay", "AutoLoadGhost", Replay.AutoLoadGhost);
@@ -67,6 +68,7 @@ void CScriptSettings::Save() {
     SAVE_VAL("Replay", "VehicleAlpha", Replay.VehicleAlpha);
     SAVE_VAL("Replay", "ForceLights", Replay.ForceLights);
 
+    SAVE_VAL("Replay", "ScrubDistanceSeconds", Replay.ScrubDistanceSeconds);
     SAVE_VAL("Replay", "FallbackModel", Replay.FallbackModel);
     SAVE_VAL("Replay", "ForceFallbackModel", Replay.ForceFallbackModel);
     SAVE_VAL("Replay", "AutoLoadGhost", Replay.AutoLoadGhost);

--- a/GhostReplay/ScriptSettings.hpp
+++ b/GhostReplay/ScriptSettings.hpp
@@ -30,6 +30,7 @@ public:
         int ForceLights = 0;
 
         // Advanced
+        double ScrubDistanceSeconds = 1.0;
         std::string FallbackModel = "sultan";
         bool ForceFallbackModel = false;
         bool AutoLoadGhost = true;


### PR DESCRIPTION
Heck, this a pain.

- Change replay/vehicle storage from 1 instance to any number of instances
- Change SetReplay to SelectReplay and DeselectReplay for multiple different instances
- Update menu implementation for multiple ghosts, keep separate summaries for 1-ghost case
- Completely change frame selection logic during scrubbing, to timestamp-based instead of local offset-based (this was the biggest PITA)
- Allow adding/removing ghosts while replaying
- Implement multi-ghost passenger mode
- Support switching between different playing ghosts
- Allow jumping into and out of passenger mode without impacting replay