### PR TITLE
Test/meta loading

### DIFF
--- a/GhostReplay/ReplayData.cpp
+++ b/GhostReplay/ReplayData.cpp
@@ -256,6 +256,7 @@ void CReplayData::WriteAsync(CReplayData& replayData) {
     std::thread([replayData, pretty]() {
         CReplayData myCopy = replayData;
         myCopy.write(pretty);
+        myCopy.writeMetadata(pretty);
     }).detach();
 }
 

--- a/GhostReplay/ReplayData.hpp
+++ b/GhostReplay/ReplayData.hpp
@@ -35,12 +35,15 @@ struct SReplayNode {
 
 class CReplayData {
 public:
-    static CReplayData Read(const std::string& replayFile);
+    static CReplayData Read(const std::string& replayFile, bool full);
     static void WriteAsync(CReplayData& replayData);
+    static void WriteMetadataSync(CReplayData& replayData);
 
     CReplayData(std::string fileName);
     std::string FileName() const { return mFileName; }
     void Delete() const;
+
+    bool FullyParsed;
 
     bool MarkedForDeletion;
 
@@ -59,6 +62,8 @@ public:
 private:
     // Make sure mFileName has been set before calling this.
     void write(bool pretty);
+    void writeMetadata(bool pretty);
+
     // Only run this before asynchronously calling write().
     void generateFileName();
 

--- a/GhostReplay/ReplayDriver.hpp
+++ b/GhostReplay/ReplayDriver.hpp
@@ -53,7 +53,9 @@ inline void from_json(const nlohmann::ordered_json& j, SReplayDriverData& replay
     j.at("Model").get_to(replayDriver.Model);
     j.at("Type").get_to(replayDriver.Type);
     j.at("ComponentVariations").get_to(replayDriver.ComponentVariations);
-    j.at("Props").get_to(replayDriver.Props);
+
+    if (j.contains("Props"))
+        j.at("Props").get_to(replayDriver.Props);
 
     if (j.contains("HeadBlendData")) {
         SHeadBlendData hbd = j.value("HeadBlendData", SHeadBlendData());

--- a/GhostReplay/ReplayMenu.cpp
+++ b/GhostReplay/ReplayMenu.cpp
@@ -435,7 +435,7 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
             bool currentReplay = false;
             const auto& activeReplays = context.ActiveReplays();
             currentReplay = std::find_if(activeReplays.begin(), activeReplays.end(),
-                [&](const CReplayData* activeReplay) {
+                [&](const auto activeReplay) {
                     return activeReplay->Name == replay->Name &&
                         activeReplay->Timestamp == replay->Timestamp;
                 }
@@ -498,6 +498,7 @@ std::vector<CScriptMenu<CReplayScript>::CSubmenu> GhostReplay::BuildMenu() {
                     Util::GetVehicleName(replay->VehicleModel)),
                 fmt::format("Time: {}",  Util::FormatMillisTime(replay->Nodes.back().Timestamp)),
                 fmt::format("Lap recorded: {}", datetime),
+                fmt::format("{}", replay->FullyParsed() ? "Loaded/Ready!" : currentReplay ? "Loading..." : "Not loaded yet."),
             };
 
             if (mbCtx.OptionPlus(optionName, extras, nullptr, clearDeleteFlag, deleteFlag, "Ghost", description)) {
@@ -968,12 +969,12 @@ const std::vector<std::string>& GhostReplay::FormatTrackData(NativeMenu::Menu& m
         }
     }
 
-    CReplayData fastestReplayInfo = context.GetFastestReplay(track.Name, 0);
+    auto fastestReplayInfo = context.GetFastestReplay(track.Name, 0);
     std::string lapRecordString = "No times set";
-    if (!fastestReplayInfo.Name.empty()) {
+    if (fastestReplayInfo != nullptr) {
         lapRecordString = fmt::format("{} ({})",
-            Util::FormatMillisTime(fastestReplayInfo.Nodes.back().Timestamp),
-            Util::GetVehicleName(fastestReplayInfo.VehicleModel));
+            Util::FormatMillisTime(fastestReplayInfo->Nodes.back().Timestamp),
+            Util::GetVehicleName(fastestReplayInfo->VehicleModel));
     }
 
     auto imgStr = context.GetTrackImageMenuString(track.Name);

--- a/GhostReplay/ReplayScript.cpp
+++ b/GhostReplay/ReplayScript.cpp
@@ -981,6 +981,9 @@ void CReplayScript::finishRecord(bool saved, const SReplayNode& node) {
         fastestLap = IsFastestLap(mCurrentRun.Track, 0, node.Timestamp);
     }
 
+    // "FullyParsed" is a lie, it just means it contains all data
+    mCurrentRun.FullyParsed = true;
+
     if (mSettings.Record.AutoGhost && (mActiveReplays.empty() || fasterLap)) {
         // Just deselect when there's 1 ghost, otherwise keep adding to the mayhem!
         if (mActiveReplays.size() == 1)

--- a/GhostReplay/ReplayScript.cpp
+++ b/GhostReplay/ReplayScript.cpp
@@ -128,6 +128,9 @@ void CReplayScript::SelectReplay(const std::string& replayName, unsigned long lo
         bool timeOK = timestamp == 0 ? true : replay->Timestamp == timestamp;
 
         if (nameOK && timeOK) {
+            if (!replay->FullyParsed)
+                *replay = replay->Read(replay->FileName(), true);
+
             mActiveReplays.push_back(&*replay);
             mReplayVehicles.push_back(std::make_unique<CReplayVehicle>(mSettings, &*replay,
                 std::bind(static_cast<void(CReplayScript::*)(int)>(&CReplayScript::ghostCleanup),

--- a/GhostReplay/ReplayScript.hpp
+++ b/GhostReplay/ReplayScript.hpp
@@ -46,7 +46,7 @@ public:
         return mUnsavedRuns;
     }
 
-    std::vector<CReplayData*> ActiveReplays() const {
+    std::vector<std::shared_ptr<CReplayData>> ActiveReplays() const {
         return mActiveReplays;
     }
 
@@ -88,7 +88,7 @@ public:
     void AddCompatibleReplay(const CReplayData& value);
 
     bool IsFastestLap(const std::string& trackName, Hash vehicleModel, double timestamp);
-    CReplayData GetFastestReplay(const std::string& trackName, Hash vehicleModel);
+    std::shared_ptr<CReplayData> GetFastestReplay(const std::string& trackName, Hash vehicleModel);
 
     bool StartLineDef(SLineDef& lineDef, const std::string& lineName);
     void DeleteTrack(const CTrackData& track);
@@ -135,8 +135,8 @@ protected:
     void startRecord(double gameTime, Vehicle vehicle);
     bool saveNode(double gameTime, SReplayNode& node, Vehicle vehicle, bool firstNode);
     void finishRecord(bool saved, const SReplayNode& node);
-    CReplayData* getFastestActiveReplay();
-    CReplayData* getSlowestActiveReplay();
+    std::shared_ptr<CReplayData> getFastestActiveReplay();
+    std::shared_ptr<CReplayData> getSlowestActiveReplay();
     void updateSlowestReplay();
 
     void clearPtfx();
@@ -162,7 +162,7 @@ protected:
     std::vector<CImage>& mTrackImages;
     std::vector<CTrackData>& mArsTracks;
 
-    std::vector<CReplayData*> mActiveReplays;
+    std::vector<std::shared_ptr<CReplayData>> mActiveReplays;
     CTrackData* mActiveTrack;
 
     std::unique_ptr<CWrappedBlip> mStartBlip;

--- a/GhostReplay/Script.cpp
+++ b/GhostReplay/Script.cpp
@@ -273,8 +273,7 @@ void GhostReplay::LoadReplays() {
                 currentLoadingReplay = std::filesystem::path(file).stem().string();
             }
 
-
-            CReplayData replay = CReplayData::Read(file);
+            CReplayData replay = CReplayData::Read(file, false);
             if (!replay.Nodes.empty()) {
                 std::lock_guard replaysLock(replaysMutex);
                 replays.push_back(std::make_shared<CReplayData>(replay));

--- a/GhostReplay/Script.cpp
+++ b/GhostReplay/Script.cpp
@@ -255,7 +255,6 @@ void GhostReplay::LoadReplays() {
 
     for (const auto& file : fs::directory_iterator(replaysPath)) {
         if (Util::to_lower(fs::path(file).extension().string()) != ".json") {
-            logger.Write(DEBUG, "[Replay] Skipping [%s] - not .json", fs::path(file).string().c_str());
             continue;
         }
         pendingReplays.push_back(fs::path(file).string());
@@ -311,7 +310,6 @@ uint32_t GhostReplay::LoadTracks() {
 
     for (const auto& file : fs::recursive_directory_iterator(tracksPath)) {
         if (Util::to_lower(fs::path(file).extension().string()) != ".json") {
-            logger.Write(DEBUG, "[Track] Skipping [%s] - not .json", fs::path(file).string().c_str());
             continue;
         }
 
@@ -389,7 +387,6 @@ uint32_t GhostReplay::LoadARSTracks() {
 
     for (const auto& file : fs::recursive_directory_iterator(tracksPath)) {
         if (Util::to_lower(fs::path(file).extension().string()) != ".xml") {
-            logger.Write(DEBUG, "[Track-ARS] Skipping [%s] - not .xml", fs::path(file).string().c_str());
             continue;
         }
 

--- a/GhostReplay/Util/Logger.hpp
+++ b/GhostReplay/Util/Logger.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -14,13 +15,15 @@ class Logger {
 
 public:
     Logger();
-    void SetFile(const std::string &fileName);
+    void SetFile(const std::string& fileName);
     void SetMinLevel(LogLevel level);
     void Clear() const;
     void Write(LogLevel level, const std::string& text) const;
-    void Write(LogLevel level, const char *fmt, ...) const;
+    void Write(LogLevel level, const char* fmt, ...) const;
+    bool Error();
 
 private:
+    mutable bool mError;
     std::string file = "";
     std::string levelText(LogLevel level) const;
     LogLevel minLevel = INFO;
@@ -31,6 +34,7 @@ private:
         " ERROR ",
         " FATAL ",
     };
+    mutable std::mutex mutex;
 };
 
 extern Logger logger;


### PR DESCRIPTION
Work in progress... ?

GhostReplay can generate large files, and is set up to generate a lot of them, if you like hotlapping and constantly improve your times. For me, my testing files have reached nearly 3GB.

The script was initially set up to just go ham and load everything in the replays folder. As development, testing and gameplay went on, this started to cause for long loading times, with the game basically being frozen for 30 seconds to a minute on my machine - depending on how much was in that folder.

In version 1.2.0, the initial loading got relegated to a background task, which worked fine. There was even some sort of progress indication.

Lately, during development of unrelated scripts, with quick loading and unloading, the script tends to get stuck and crash due to the long-running background loading task. So experiments started to get this time down (or I could just throw out old recordings, but where's the fun in that?)

Changes in this PR:

- Generate metadata files with just the basic info: Timestamp, Name, Track, VehicleModel and the start/finish nodes (just timestamp and coords).
- Defer loading the full file until user selection
- Load full file in background to prevent 2~5 second game freezes during large files

A few challenges remain:

- Crash occurs when node(?) fields are accessed during loading
- Still a small performance hitch when a new replay is selected, duration unrelated with file size

It's probably fine to merge this after those two issues get sorted out and the code gets tidied up a bit. But for now, it'll linger in this PR.